### PR TITLE
without "scrollToBlockInPage"

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -19,20 +19,20 @@ type PathItem = {
 
 
 const scrollTo = async (blockUuid: string) => {
-	const pageOrBlock = (await logseq.Editor.getCurrentPage());
-	const isBlock = ('content' in (pageOrBlock || {}));
-	if (!pageOrBlock) {
-		return console.error('failed to get page or block');
+	const currentBlock: any = logseq.Editor.getCurrentBlock();
+	if (blockUuid === currentBlock?.uuid) {
+		return;
 	}
-	const page = isBlock
-		? await logseq.Editor.getPage(pageOrBlock.page.id)
-		: pageOrBlock;
-	if (!page) {
-		return console.error('failed to get page');
-	}
+	const currentPage: any = await logseq.Editor.getCurrentPage();
+	const anchor = `block-content-` + blockUuid;
 	// TODO: how to scroll to block in sub-tree without leaving the sub-tree?
 	// `scrollToBlockInPage()` will open the entire page
-	logseq.Editor.scrollToBlockInPage(page.name, blockUuid);
+	if (currentPage?.name) {
+		//logseq.Editor.scrollToBlockInPage(currentPage.name, blockUuid);
+		if (blockUuid !== currentPage?.uuid) {
+			logseq.App.pushState('page', { name: currentPage.name }, { anchor });
+		}
+	}
 };
 
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,7 +26,7 @@ const settings: SettingSchemaDesc[] = [
 	{
 		key: 'autoOpen',
 		title: 'Auto-open palette',
-		description: 'Autmatically open the palette on opening a page',
+		description: 'Automatically open the palette on opening a page',
 		default: false,
 		type: 'boolean',
 	},
@@ -50,16 +50,16 @@ const main = async () => {
 	);
 
 	// auto open
-	const PageSet = new Set();
+	let PageSet = "";
 	logseq.App.onRouteChanged(async (event) => {
 		const autoOpen = logseq.settings?.autoOpen || '';
 		if (autoOpen === true) {
 			if (event && event.template === '/page/:name') {
-				if (!PageSet.has(event.path)) {
-					PageSet.clear();
+				if (PageSet !== event.path) {
+					PageSet = "";
 					logseq.showMainUI({ autoFocus: false });
 				}
-				await PageSet.add(event.path);
+				PageSet = event.path;
 			}
 		}
 	});
@@ -69,7 +69,6 @@ const main = async () => {
 		'toolbar',
 		{
 			key: 'jump-to-block',
-			// TODO: add icon
 			template: `${makeToolbarIcon(cmdLabel)}\n`,
 		}
 	);


### PR DESCRIPTION
Fixed an issue where the zoomed page could not be opened https://github.com/freder/logseq-plugin-jump-to-block/issues/8

Other issues remain.
If remove the command palette after hovering over it, it scrolls to the block at the top of the page. It behaves differently than when click on the command palette. But I couldn't find the cause from the source.
